### PR TITLE
feat: Enhance statistics display and add reset functionality

### DIFF
--- a/api/profile/get_progress.php
+++ b/api/profile/get_progress.php
@@ -10,29 +10,68 @@ if (!isset($_SESSION['user_id'])) {
 
 $user_id = $_SESSION['user_id'];
 
-$sql = "SELECT
-            p.theme,
-            p.section,
-            COUNT(DISTINCT up.phrase_id) as phrases_covered,
-            AVG(up.matching_quality) as average_matching_quality,
-            (SELECT COUNT(*) FROM phrases WHERE theme = p.theme AND section = p.section) as total_phrases
-        FROM user_progress up
-        JOIN phrases p ON up.phrase_id = p.id
-        WHERE up.user_id = ?
-        GROUP BY p.theme, p.section";
-
-$stmt = $conn->prepare($sql);
-$stmt->bind_param("i", $user_id);
-$stmt->execute();
-$result = $stmt->get_result();
-
-$progress = [];
-while ($row = $result->fetch_assoc()) {
-    $progress[] = $row;
+// 1. Fetch all unique themes and sections, and their total phrase counts
+$all_topics_sql = "SELECT
+                        theme,
+                        section,
+                        COUNT(*) as total_phrases
+                   FROM phrases
+                   GROUP BY theme, section";
+$all_topics_result = $conn->query($all_topics_sql);
+$all_topics = [];
+while ($row = $all_topics_result->fetch_assoc()) {
+    $all_topics[] = $row;
 }
 
-echo json_encode(['status' => 'success', 'progress' => $progress]);
+// 2. Fetch user's actual progress
+$user_progress_sql = "SELECT
+                        p.theme,
+                        p.section,
+                        COUNT(DISTINCT up.phrase_id) as phrases_covered,
+                        AVG(up.matching_quality) as average_matching_quality
+                      FROM user_progress up
+                      JOIN phrases p ON up.phrase_id = p.id
+                      WHERE up.user_id = ?
+                      GROUP BY p.theme, p.section";
+$stmt = $conn->prepare($user_progress_sql);
+$stmt->bind_param("i", $user_id);
+$stmt->execute();
+$user_progress_result = $stmt->get_result();
 
+$user_progress_map = [];
+while ($row = $user_progress_result->fetch_assoc()) {
+    $key = $row['theme'] . '|' . $row['section'];
+    $user_progress_map[$key] = $row;
+}
 $stmt->close();
+
+// 3. Combine the two lists
+$final_progress = [];
+foreach ($all_topics as $topic) {
+    $key = $topic['theme'] . '|' . $topic['section'];
+    if (isset($user_progress_map[$key])) {
+        // User has progress for this topic
+        $progress_item = $user_progress_map[$key];
+        $final_progress[] = [
+            'theme' => $topic['theme'],
+            'section' => $topic['section'],
+            'phrases_covered' => (int)$progress_item['phrases_covered'],
+            'average_matching_quality' => (float)$progress_item['average_matching_quality'],
+            'total_phrases' => (int)$topic['total_phrases']
+        ];
+    } else {
+        // User has no progress for this topic, add default entry
+        $final_progress[] = [
+            'theme' => $topic['theme'],
+            'section' => $topic['section'],
+            'phrases_covered' => 0,
+            'average_matching_quality' => 0,
+            'total_phrases' => (int)$topic['total_phrases']
+        ];
+    }
+}
+
+echo json_encode(['status' => 'success', 'progress' => $final_progress]);
+
 $conn->close();
 ?>

--- a/api/profile/reset_progress.php
+++ b/api/profile/reset_progress.php
@@ -1,0 +1,27 @@
+<?php
+require_once __DIR__ . '/../../db/db_config.php';
+session_start();
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['status' => 'error', 'message' => 'User not logged in']);
+    exit;
+}
+
+$user_id = $_SESSION['user_id'];
+
+$sql = "DELETE FROM user_progress WHERE user_id = ?";
+
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("i", $user_id);
+
+if ($stmt->execute()) {
+    echo json_encode(['status' => 'success', 'message' => 'Your progress has been reset.']);
+} else {
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => 'Failed to reset progress.']);
+}
+
+$stmt->close();
+$conn->close();
+?>

--- a/db/logs/php_debug.log
+++ b/db/logs/php_debug.log
@@ -425,3 +425,20 @@
     [subscription_status] => active
 )
 
+[2025-08-07 13:37:52] Login successful. Session data set for user: jules@test.com
+[2025-08-07 13:37:52] Array
+(
+    [user_id] => 2
+    [first_name] => Jules
+    [role] => user
+    [subscription_status] => inactive
+)
+
+[2025-08-07 13:39:15] Login successful. Session data set for user: jules@test.com
+[2025-08-07 13:39:15] Array
+(
+    [user_id] => 2
+    [first_name] => Jules
+    [role] => user
+    [subscription_status] => inactive
+)

--- a/profile.html
+++ b/profile.html
@@ -94,6 +94,9 @@
         <div class="form-section">
             <h2>Your Progress</h2>
             <div id="progress-container"></div>
+            <div style="margin-top: 1rem;">
+                <button id="reset-stats-btn" style="background-color: #dc3545;">Reset Stats</button>
+            </div>
         </div>
     </div>
 
@@ -147,6 +150,26 @@
         }
 
         fetchProgress();
+
+        document.getElementById('reset-stats-btn').addEventListener('click', async () => {
+            if (confirm('Are you sure you want to reset your stats? This action cannot be undone.')) {
+                try {
+                    const response = await fetch('api/profile/reset_progress.php', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                    const data = await response.json();
+                    if (data.status === 'success') {
+                        showToast('Your stats have been reset.', 'success');
+                        fetchProgress();
+                    } else {
+                        showToast(data.message || 'Failed to reset stats.', 'error');
+                    }
+                } catch (error) {
+                    showToast('An error occurred while resetting your stats.', 'error');
+                }
+            }
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces two main improvements to the user profile page's statistics section:

1.  **Display all themes in statistics:** The statistics table now displays all available themes, regardless of whether the user has started them. Themes that have not been started will show 0 progress. This provides a more comprehensive overview of the user's progress.

2.  **Add "Reset Stats" button:** A "Reset Stats" button has been added below the progress table. This button allows users to reset their statistics to their initial state. A confirmation dialog is included to prevent accidental resets.