### PR TITLE
fix: Correct Phase 2 UI and add more drill phrases

### DIFF
--- a/db/setup_database.php
+++ b/db/setup_database.php
@@ -9,7 +9,8 @@ $sql_files = [
     __DIR__ . '/../sql/update_user_tracking.sql',
     __DIR__ . '/../sql/create_training_tables.sql',
     __DIR__ . '/../sql/alter_roleplay_scenarios.sql',
-    __DIR__ . '/../sql/update_roleplay_scenarios_level2.sql'
+    __DIR__ . '/../sql/update_roleplay_scenarios_level2.sql',
+    __DIR__ . '/../sql/add_more_drills.sql'
 ];
 
 echo "<h2>Database Setup</h2>";

--- a/sql/add_more_drills.sql
+++ b/sql/add_more_drills.sql
@@ -1,0 +1,15 @@
+-- Add more diverse question drills for Phase 2
+INSERT INTO `question_drills` (`theme`, `section`, `english_question`, `french_vocab_hints`, `expected_answer`) VALUES
+('le_logement', 'section_a', 'Is the apartment still available?', 'appartement, toujours, disponible', 'Est-ce que l''appartement est toujours disponible?'),
+('le_logement', 'section_a', 'How much is the rent per month?', 'loyer, par, mois, combien', 'Combien coûte le loyer par mois?'),
+('le_logement', 'section_a', 'Are utilities included?', 'charges, comprises, est-ce que', 'Est-ce que les charges sont comprises?'),
+('le_logement', 'section_a', 'Is there a washing machine?', 'machine à laver, y a-t-il, dans', 'Y a-t-il une machine à laver dans l''appartement?'),
+('le_travail', 'section_a', 'What type of contract is it?', 'type, contrat, quel', 'Quel type de contrat proposez-vous?'),
+('le_travail', 'section_a', 'Is it possible to work from home?', 'télétravail, possible, faire', 'Est-ce qu''il est possible de faire du télétravail?'),
+('le_travail', 'section_a', 'What are the benefits?', 'avantages, sociaux, quels sont', 'Quels sont les avantages sociaux?'),
+('les_transports', 'section_a', 'How do I get to the city center?', 'comment, aller, centre-ville', 'Comment puis-je aller au centre-ville?'),
+('les_transports', 'section_a', 'Does this bus go to the airport?', 'bus, va, aéroport', 'Est-ce que ce bus va à l''aéroport?'),
+('les_transports', 'section_a', 'Where can I buy a ticket?', 'où, acheter, billet', 'Où est-ce que je peux acheter un billet?'),
+('la_vie_de_tous_les_jours', 'section_a', 'Can you recommend a good restaurant nearby?', 'recommander, bon, restaurant, près d''ici', 'Pouvez-vous me recommander un bon restaurant près d''ici?'),
+('la_vie_de_tous_les_jours', 'section_a', 'What time do you open?', 'à, quelle, heure, ouvrez-vous', 'À quelle heure ouvrez-vous?'),
+('la_vie_de_tous_les_jours', 'section_a', 'Do you accept credit cards?', 'acceptez-vous, cartes, crédit', 'Acceptez-vous les cartes de crédit?');

--- a/training.html
+++ b/training.html
@@ -57,6 +57,70 @@
   .training-module.active {
       display: block; /* Shown when active */
   }
+
+  /* --- Flashcard Styles --- */
+  .flashcard {
+      background-color: transparent;
+      width: 100%;
+      max-width: 600px;
+      height: 200px;
+      perspective: 1000px;
+      margin: auto;
+      margin-bottom: 1rem;
+  }
+  .flashcard-inner {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      text-align: center;
+      transition: transform 0.6s;
+      transform-style: preserve-3d;
+      box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
+  }
+  .flashcard.is-flipped .flashcard-inner {
+      transform: rotateY(180deg);
+  }
+  .flashcard-front, .flashcard-back {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      -webkit-backface-visibility: hidden;
+      backface-visibility: hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 8px;
+      background-color: #fff;
+      padding: 1rem;
+      box-sizing: border-box;
+  }
+  .flashcard-back {
+      transform: rotateY(180deg);
+  }
+
+  /* --- Responsive Design --- */
+  @media (max-width: 640px) {
+    body {
+      margin: 1rem;
+    }
+    h1 {
+      font-size: 1.5rem;
+    }
+    .flashcard {
+        height: 180px; /* Adjust height for smaller screens */
+    }
+    #user-status {
+      position: static;
+      text-align: center;
+      margin-bottom: 1rem;
+      padding: 0.5rem;
+      background: #e9ecef;
+      border-radius: 4px;
+    }
+    #user-status a, #user-status button {
+        margin: 0 0.5rem;
+    }
+  }
 </style>
 </head>
 <body>


### PR DESCRIPTION
This commit addresses two issues in the Phase 2 "Question Drills" feature:
1. The flashcards were not styled correctly and lacked the flip animation. This has been fixed by copying the necessary CSS rules from `index.html` to `training.html`.
2. There was not enough content for the drill. This has been addressed by adding 13 new, diverse question drills to the database.