### PR TITLE
fix: Correct 'Show Answer' button behavior and layout

### DIFF
--- a/training.html
+++ b/training.html
@@ -452,11 +452,12 @@ document.addEventListener('DOMContentLoaded', () => {
         drillCardBack.innerHTML = `
             <div>
                 <p><strong>Hints:</strong> ${drill.french_vocab_hints}</p>
-                <button class="show-answer-btn" style="margin-top: 1rem;">Show Answer</button>
+                <div class="drill-answer" style="display: none;">
+                    <br><br>
+                    <p><strong>Expected:</strong> ${drill.expected_answer}</p>
+                </div>
             </div>
-            <div class="drill-answer" style="display: none; margin-top: 1rem;">
-                <p><strong>Expected:</strong> ${drill.expected_answer}</p>
-            </div>
+            <button class="show-answer-btn" style="margin-top: 1rem;">Show Answer</button>
         `;
         drillPagination.textContent = `Card ${index + 1} of ${drills.length}`;
         updateDrillNav();
@@ -500,6 +501,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     drillCardBack.addEventListener('click', (e) => {
         if (e.target.classList.contains('show-answer-btn')) {
+            e.stopPropagation(); // Prevent the click from bubbling up to the flashcard
             const answerContainer = e.target.closest('.flashcard-back').querySelector('.drill-answer');
             if (answerContainer) {
                 answerContainer.style.display = 'block';


### PR DESCRIPTION
This commit fixes two issues with the "Show Answer" button on the Phase 2 "Question Drills" flashcards:
1. An event propagation bug was causing the card to flip back to the front when the "Show Answer" button was clicked. This has been fixed by adding `event.stopPropagation()` to the click handler.
2. The layout of the back of the card was adjusted to place the answer directly below the hints and move the "Show Answer" button, improving the user experience.