### PR TITLE
fix: Timer no longer stops on manual card flip in Phase 2

### DIFF
--- a/training.html
+++ b/training.html
@@ -473,7 +473,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function flipDrillCard() {
         drillFlashcard.classList.toggle('is-flipped');
-        clearInterval(drillTimer);
     }
 
     function resetTimer() {
@@ -485,7 +484,10 @@ document.addEventListener('DOMContentLoaded', () => {
             timerDisplay.textContent = timeLeft;
             if (timeLeft <= 0) {
                 clearInterval(drillTimer);
-                flipDrillCard();
+                // Only flip if it's not already flipped
+                if (!drillFlashcard.classList.contains('is-flipped')) {
+                    drillFlashcard.classList.add('is-flipped');
+                }
             }
         }, 1000);
     }


### PR DESCRIPTION
This commit changes the behavior of the timer in the Phase 2 "Question Drills" feature based on your feedback.

Previously, the timer would stop as soon as you manually flipped the card. Now, the timer will continue to count down to zero, regardless of whether the card has been flipped.

The logic has also been updated to prevent the timer from flipping the card back to the front if it was already flipped by you when the timer reaches zero.