### PR TITLE
fix: Correct mobile speech recognition behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -836,10 +836,9 @@
       };
 
       recognition.onend = () => {
-        const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
-        if (isMobile) {
-            stopRecording();
-        }
+        // The 'onspeechend' event is more reliable for stopping the recording.
+        // This onend event can fire prematurely on some mobile browsers.
+        startRecordBtn.disabled = false;
       };
     } catch (err) {
       recordingResult.textContent = 'Microphone access denied or error: ' + err.message;


### PR DESCRIPTION
The speech recognition feature was not working correctly on mobile devices. The `onend` event for the Web Speech API was being fired prematurely on some mobile browsers, which caused the recognition to stop before any results could be processed.

This commit removes the mobile-specific code from the `recognition.onend` event handler in `index.html`. The `onspeechend` event is now used to reliably stop the recording, which ensures that the speech recognition works as expected on both mobile and desktop devices.