### PR TITLE
fix: Change login to use form data instead of JSON

### DIFF
--- a/api/login.php
+++ b/api/login.php
@@ -10,16 +10,13 @@ try {
         throw new Exception('Invalid request method.', 405);
     }
 
-    // Get the posted data
-    $data = json_decode(file_get_contents('php://input'), true);
-
-    // Basic validation
-    if (!$data || !isset($data['email']) || !isset($data['password'])) {
+    // Get the posted data from $_POST
+    if (!isset($_POST['email']) || !isset($_POST['password'])) {
         throw new Exception('Missing email or password.', 400);
     }
 
-    $email = trim($data['email']);
-    $password = trim($data['password']);
+    $email = trim($_POST['email']);
+    $password = trim($_POST['password']);
 
     if (empty($email) || empty($password)) {
         throw new Exception('Email and password are required.', 400);

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,12 +1,13 @@
 // Function to handle API requests
 async function apiRequest(url, data) {
     try {
+        const urlSearchParams = new URLSearchParams(Object.entries(data));
         const response = await fetch(url, {
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/x-www-form-urlencoded'
             },
-            body: JSON.stringify(data)
+            body: urlSearchParams
         });
 
         const result = await response.json();


### PR DESCRIPTION
This commit changes the login process to use `application/x-www-form-urlencoded` instead of `application/json`. This is to address a persistent issue where the server was not receiving the login credentials from the client.

Changes include:
- Modified `js/auth.js` to send login data as form data.
- Modified `api/login.php` to read login data from the `$_POST` superglobal.