### PR TITLE
fix(speech-recognition): Add timeout workaround for iOS/Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -846,6 +846,20 @@
     };
 
     recognition.start();
+
+    // iOS/Safari has a bug where it doesn't fire onspeechend and doesn't return a result
+    // until recognition.stop() is called. This timeout is a workaround to force it.
+    const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+    if (isIOS) {
+      console.log('iOS device detected. Setting 5s timeout to stop recognition.');
+      setTimeout(() => {
+        // Check if recognition is still active before stopping
+        if (recognition) {
+          console.log('iOS timeout reached. Forcing recognition.stop().');
+          recognition.stop();
+        }
+      }, 5000);
+    }
   };
 
   function stopRecording() {


### PR DESCRIPTION
The speech recognition feature was still failing on iPhones after disabling the MediaRecorder. The process would hang and eventually time out with an `audio-capture` error.

This is likely caused by a bug in Safari's implementation of the Web Speech API, where the `onresult` and `onend` events do not fire until `recognition.stop()` is explicitly called.

This commit introduces a workaround specifically for iOS devices:
- It detects if the user agent is iOS.
- If it is, a 5-second timeout is set when recognition starts.
- The timeout's callback calls `recognition.stop()`, which should force the browser to process the captured audio and return a result.

This change is designed to be iOS-specific and should not affect the functionality on Android or desktop browsers.