### PR TITLE
refactor: Use environment variables for AWS credentials

### DIFF
--- a/api/services/EmailService.php
+++ b/api/services/EmailService.php
@@ -5,13 +5,7 @@ use Aws\Ses\SesClient;
 use Aws\Exception\AwsException;
 
 function sendEmail($recipient, $subject, $body_html, $body_text) {
-    // TODO: Replace with your AWS credentials and region
-    $aws_key = 'AKIA5SGXHWFP2UEGBIO7';
-    $aws_secret = 'YOUR_AWS_SECRET_ACCESS_KEY';
-    $aws_region = 'us-east-1'; // e.g., 'us-east-1'
-
-    // TODO: Replace with a sender email address that you have verified with Amazon SES.
-    $sender_email = 'tefinitely@gmail.com';
+    global $aws_key, $aws_secret, $aws_region, $sender_email;
 
     $client = new SesClient([
         'version'     => 'latest',

--- a/db/db_config.php
+++ b/db/db_config.php
@@ -13,6 +13,14 @@ if ($conn->connect_error) {
 }
 $conn->set_charset("utf8mb4");  // IMPORTANT: Set charset to utf8mb4 here
 
+// --- AWS SES Configuration ---
+// Load from environment variables.
+// The fallback values are for development purposes and should not be used in production.
+$aws_key = getenv('AWS_ACCESS_KEY_ID') ?: 'AKIA5SGXHWFP2UEGBIO7';
+$aws_secret = getenv('AWS_SECRET_ACCESS_KEY') ?: 'YOUR_AWS_SECRET_ACCESS_KEY';
+$aws_region = getenv('AWS_REGION') ?: 'us-east-1';
+$sender_email = getenv('SENDER_EMAIL') ?: 'YOUR_SENDER_EMAIL';
+
 // --- Debug Logging Function ---
 // function debug_log($message) {
 //     $log_file = __DIR__ . '/logs/php_debug.log';


### PR DESCRIPTION
This commit refactors the AWS SES configuration to use environment variables instead of hardcoded values. This is a security best practice that prevents secrets from being committed to the repository.

The `db/db_config.php` file has been updated to read the following environment variables:
- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`
- `AWS_REGION`
- `SENDER_EMAIL`

Fallback values are provided for development convenience, but environment variables should be set in production.