### PR TITLE
Fix: Prevent page crash on session check failure.

### DIFF
--- a/index.html
+++ b/index.html
@@ -818,9 +818,13 @@
           }
       } catch (error) {
           console.error('Session check failed:', error);
+          // Gracefully handle the error by showing the landing page with an error message
           authContainer.style.display = 'block';
-          loginMessage.textContent = 'An error occurred. Please try again later.';
           loginPrompt.style.display = 'block';
+          const heroH1 = loginPrompt.querySelector('.hero h1');
+          const heroP = loginPrompt.querySelector('.hero p');
+          if (heroH1) heroH1.textContent = 'Oops! Something went wrong.';
+          if (heroP) heroP.textContent = 'We couldn\'t load the page properly. Please try refreshing. If the problem persists, please contact support.';
       }
   });
 


### PR DESCRIPTION
A previous refactor of your landing page removed the `#login-message` element, but the `catch` block for the `check_session` API call still contained a reference to it. This caused a `TypeError: Cannot set properties of null` if the fetch operation failed for any reason, which halted script execution and resulted in a blank page for you.

This commit fixes the bug by updating the `catch` block to no longer reference the non-existent element. Instead, it now gracefully displays a user-friendly error message within the hero section of the existing landing page design.

I verified the fix by simulating a network failure to confirm that the correct error state is displayed without crashing the page.