### PR TITLE
I've just fixed an issue with your session check logic.

### DIFF
--- a/index.html
+++ b/index.html
@@ -797,48 +797,49 @@
 
       try {
           const response = await fetch('api/check_session.php');
-          const data = await response.json();
 
-          if (response.ok && data.loggedIn) {
-              // User is logged in
-              firstNameDisplay.textContent = `Welcome, ${data.user.first_name}`;
-              userStatusDiv.style.display = 'block';
+          if (response.ok) {
+              const data = await response.json();
+              if (data.loggedIn) {
+                  // User is logged in
+                  firstNameDisplay.textContent = `Welcome, ${data.user.first_name}`;
+                  userStatusDiv.style.display = 'block';
+                  if (data.user.role === 'admin') {
+                      document.getElementById('admin-link').style.display = 'inline';
+                  }
 
-              // Show admin link if user is an admin
-              if (data.user.role === 'admin') {
-                  document.getElementById('admin-link').style.display = 'inline';
-              }
-
-              if (data.user.subscription_status === 'active') {
-                  // Active subscription, show the main content
-                  mainContentDiv.style.display = 'block';
-                  if (!data.user.tour_completed) {
-                      showTourStep(0);
-                  } else if (data.user.last_topic) {
-                      topicSelect.value = data.user.last_topic;
-                      loadPhrases(data.user.last_topic, data.user.last_card_index);
+                  if (data.user.subscription_status === 'active') {
+                      mainContentDiv.style.display = 'block';
+                      if (!data.user.tour_completed) {
+                          showTourStep(0);
+                      } else if (data.user.last_topic) {
+                          topicSelect.value = data.user.last_topic;
+                          loadPhrases(data.user.last_topic, data.user.last_card_index);
+                      }
+                  } else {
+                      // Logged in but not subscribed
+                      authContainer.style.display = 'block';
+                      subscriptionPrompt.style.display = 'block';
+                      const checkPayPal = setInterval(() => {
+                          if (typeof paypal !== 'undefined') {
+                              clearInterval(checkPayPal);
+                              renderPayPalSubscriptionButton();
+                          }
+                      }, 100);
                   }
               } else {
-                  // Logged in but no active subscription
+                  // Should not happen with a 200 OK, but as a fallback
                   authContainer.style.display = 'block';
-                  subscriptionPrompt.style.display = 'block';
-                  // Wait for PayPal SDK to be loaded
-                  const checkPayPal = setInterval(() => {
-                    if (typeof paypal !== 'undefined') {
-                        clearInterval(checkPayPal);
-                        renderPayPalSubscriptionButton();
-                    }
-                  }, 100);
+                  loginPrompt.style.display = 'block';
               }
           } else {
-              // User is not logged in
+              // Handle non-ok responses (like 401, 500) as a logged-out state
               authContainer.style.display = 'block';
-              loginMessage.textContent = 'Please log in to access the content.';
               loginPrompt.style.display = 'block';
           }
       } catch (error) {
-          console.error('Session check failed:', error);
-          // Gracefully handle the error by showing the landing page with an error message
+          // This catch block is now only for genuine network errors
+          console.error('Session check failed due to a network error:', error);
           authContainer.style.display = 'block';
           loginPrompt.style.display = 'block';
           const heroH1 = loginPrompt.querySelector('.hero h1');


### PR DESCRIPTION
Previously, it was incorrectly showing a generic "Oops! Something went wrong" error message to your logged-out users. This was because a 401 Unauthorized response from the server—which is expected for logged-out users—was causing a JSON parsing error that was then caught by the generic error handler.

To fix this, I refactored the logic to be more robust:
1.  I now check if the response is okay (`response.ok`) before attempting to parse the JSON body.
2.  A response that isn't okay (like a 401) is now correctly treated as a normal logged-out state, showing the marketing landing page to your users.
3.  The generic error handler (`catch` block) is now correctly reserved for actual network failures (for example, if your server is offline), where the "Oops" message is appropriate.

This change ensures your users see the correct interface for their state and improves the reliability of your application's entry point. I have already verified the fix for both the 401 and network failure scenarios.