### PR TITLE
Fix: Correct variable names in main flashcard initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -655,7 +655,7 @@ function initializeMainFlashcard() {
     playPhraseBtn.addEventListener('click', () => { if (phraseFrench.textContent) speakFrench(phraseFrench.textContent, speechRate); });
     firstCardBtn.addEventListener('click', () => { if (currentPhraseIndex > 0) displayPhrase(0); });
 
-    prevBtn.addEventListener('click', () => {
+    prevPhraseBtn.addEventListener('click', () => {
         if (currentPhraseIndex > 0) {
             phraseBox.classList.add('slide-out-right');
             setTimeout(() => {
@@ -665,7 +665,7 @@ function initializeMainFlashcard() {
         }
     });
 
-    nextBtn.addEventListener('click', () => {
+    nextPhraseBtn.addEventListener('click', () => {
         if (currentPhraseIndex < phrases.length - 1) {
             phraseBox.classList.add('slide-out-left');
             setTimeout(() => {
@@ -680,8 +680,8 @@ function initializeMainFlashcard() {
     flashcard.addEventListener('touchend', e => {
         const touchendX = e.changedTouches[0].screenX;
         if (Math.abs(touchendX - touchstartX) > 50) {
-            if (touchendX < touchstartX) nextBtn.click();
-            else prevBtn.click();
+            if (touchendX < touchstartX) nextPhraseBtn.click();
+            else prevPhraseBtn.click();
         }
     });
 


### PR DESCRIPTION
Resolved a `ReferenceError: prevBtn is not defined` that occurred when a user is logged in. The issue was caused by incorrect variable names (`prevBtn`, `nextBtn`) being used in event listeners within the `initializeMainFlashcard` function.

This commit replaces them with the correct variable names (`prevPhraseBtn`, `nextPhraseBtn`), which are properly defined within the function's scope. This restores the functionality of the previous/next and swipe controls for the main flashcards.