### PR TITLE
Feat: Flip card to front before navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -663,6 +663,7 @@ function initializeMainFlashcard() {
 
     prevPhraseBtn.addEventListener('click', () => {
         if (currentPhraseIndex > 0) {
+            flashcard.classList.remove('is-flipped');
             phraseBox.classList.add('slide-out-right');
             setTimeout(() => {
                 currentPhraseIndex--;
@@ -674,6 +675,7 @@ function initializeMainFlashcard() {
 
     nextPhraseBtn.addEventListener('click', () => {
         if (currentPhraseIndex < phrases.length - 1) {
+            flashcard.classList.remove('is-flipped');
             phraseBox.classList.add('slide-out-left');
             setTimeout(() => {
                 currentPhraseIndex++;


### PR DESCRIPTION
I've implemented a new feature for the main flashcards based on your feedback.

When you click the 'next' or 'previous' buttons, the flashcard will now automatically flip back to its front side (English) before the slide animation to the next card begins. This provides a more consistent and intuitive experience.