### PR TITLE
Feat: Make logo a link to the homepage

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -57,7 +57,7 @@
 </head>
 <body>
     <header>
-        <img src="img/top_logo_light.png" alt="TEFinitely Logo" class="logo">
+        <a href="index.html"><img src="img/top_logo_light.png" alt="TEFinitely Logo" class="logo"></a>
     </header>
     <div id="toast-container"></div>
     <div id="admin-dashboard" style="display: none;">

--- a/forgot_password.html
+++ b/forgot_password.html
@@ -22,7 +22,7 @@
 </head>
 <body>
     <header>
-        <img src="img/top_logo_light.png" alt="TEFinitely Logo" class="logo">
+        <a href="index.html"><img src="img/top_logo_light.png" alt="TEFinitely Logo" class="logo"></a>
     </header>
     <div class="container">
         <h1>Forgot Password</h1>

--- a/index.html
+++ b/index.html
@@ -407,7 +407,7 @@
 </head>
 <body>
 <header>
-    <img src="img/top_logo_light.png" alt="TEFinitely Logo" class="logo">
+    <a href="index.html"><img src="img/top_logo_light.png" alt="TEFinitely Logo" class="logo"></a>
 </header>
 <div id="toast-container"></div>
 <div id="user-status" style="display: none;">

--- a/login.html
+++ b/login.html
@@ -26,7 +26,7 @@
 </head>
 <body>
     <header>
-        <img src="img/top_logo_light.png" alt="TEFinitely Logo" class="logo">
+        <a href="index.html"><img src="img/top_logo_light.png" alt="TEFinitely Logo" class="logo"></a>
     </header>
     <div id="toast-container"></div>
     <div class="container">

--- a/profile.html
+++ b/profile.html
@@ -48,7 +48,7 @@
 </head>
 <body>
     <header>
-        <img src="img/top_logo_light.png" alt="TEFinitely Logo" class="logo">
+        <a href="index.html"><img src="img/top_logo_light.png" alt="TEFinitely Logo" class="logo"></a>
     </header>
     <div class="container">
         <div id="profile-details" class="profile-info" style="position: relative;">

--- a/register.html
+++ b/register.html
@@ -26,7 +26,7 @@
 </head>
 <body>
     <header>
-        <img src="img/top_logo_light.png" alt="TEFinitely Logo" class="logo">
+        <a href="index.html"><img src="img/top_logo_light.png" alt="TEFinitely Logo" class="logo"></a>
     </header>
     <div id="toast-container"></div>
     <div class="container">

--- a/reset_password.html
+++ b/reset_password.html
@@ -21,7 +21,7 @@
 </head>
 <body>
     <header>
-        <img src="img/top_logo_light.png" alt="TEFinitely Logo" class="logo">
+        <a href="index.html"><img src="img/top_logo_light.png" alt="TEFinitely Logo" class="logo"></a>
     </header>
     <div class="container">
         <h1>Reset Your Password</h1>


### PR DESCRIPTION
I've wrapped the main site logo in an anchor tag (`<a>`) across all relevant pages, making it a clickable link that navigates you back to `index.html`.

This change improves site-wide navigation and provides a consistent user experience.

Files modified:
- admin.html
- forgot_password.html
- index.html
- login.html
- profile.html
- register.html
- reset_password.html