### PR TITLE
feat: Add admin email sender functionality

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -87,6 +87,33 @@
             </tbody>
             </table>
         </div>
+
+        <div id="email-sender-section" style="margin-top: 3rem; background: white; padding: 2rem; border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
+            <h2>Email Broadcaster</h2>
+            <form id="email-form">
+                <label for="email-target">Select Target Audience</label><br>
+                <select id="email-target" style="width: 100%; padding: 0.5rem; margin-bottom: 1rem; font-size: 1rem; border: 1px solid #ccc; border-radius: 4px;">
+                    <option value="active">Active Subscribers</option>
+                    <option value="inactive">Inactive Subscribers</option>
+                    <option value="all">All Users</option>
+                    <option value="manual">Manual List</option>
+                </select>
+
+                <div id="manual-emails-container" style="display: none;">
+                    <label for="manual-emails">Enter Email Addresses (comma-separated)</label><br>
+                    <textarea id="manual-emails" rows="4" style="width: 100%; padding: 0.5rem; margin-bottom: 1rem; font-size: 1rem; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box;"></textarea>
+                </div>
+
+                <label for="email-subject">Email Subject</label><br>
+                <input type="text" id="email-subject" style="width: 100%; padding: 0.5rem; margin-bottom: 1rem; font-size: 1rem; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box;">
+
+                <label for="email-body">Email Body (HTML is supported)</label><br>
+                <textarea id="email-body" rows="10" style="width: 100%; padding: 0.5rem; margin-bottom: 1rem; font-size: 1rem; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box;"></textarea>
+
+                <button type="button" id="send-emails-btn" class="action-btn">Send Emails</button>
+                <span id="email-status" style="margin-left: 1rem; font-weight: bold;"></span>
+            </form>
+        </div>
     </div>
     <div id="auth-error" style="display: none; text-align: center; margin-top: 5rem;">
         <h2>Access Denied</h2>

--- a/api/admin/send_email.php
+++ b/api/admin/send_email.php
@@ -1,0 +1,99 @@
+<?php
+session_start();
+header('Content-Type: application/json; charset=utf-8');
+
+// Security Check: Ensure user is an admin
+if (!isset($_SESSION['role']) || $_SESSION['role'] !== 'admin') {
+    http_response_code(403); // Forbidden
+    echo json_encode(['status' => 'error', 'message' => 'Administrator access required.']);
+    exit;
+}
+
+require_once '../../db/db_config.php';
+require_once __DIR__ . '/../services/EmailService.php';
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+if ($method === 'POST') {
+    $data = json_decode(file_get_contents('php://input'), true);
+
+    $target = $data['target'] ?? '';
+    $subject = $data['subject'] ?? '';
+    $body_html = $data['body'] ?? '';
+    $manual_emails = $data['manual_emails'] ?? '';
+
+    if (empty($subject) || empty($body_html)) {
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'message' => 'Subject and body cannot be empty.']);
+        exit;
+    }
+
+    $recipients = [];
+    if ($target === 'manual') {
+        $emails = explode(',', $manual_emails);
+        foreach ($emails as $email) {
+            $trimmed_email = trim($email);
+            if (filter_var($trimmed_email, FILTER_VALIDATE_EMAIL)) {
+                $recipients[] = $trimmed_email;
+            }
+        }
+    } else {
+        $query = "";
+        if ($target === 'active') {
+            $query = "SELECT email FROM users WHERE subscription_status = 'active'";
+        } elseif ($target === 'inactive') {
+            $query = "SELECT email FROM users WHERE subscription_status = 'inactive'";
+        } elseif ($target === 'all') {
+            $query = "SELECT email FROM users";
+        }
+
+        if (!empty($query)) {
+            $result = $conn->query($query);
+            while ($row = $result->fetch_assoc()) {
+                $recipients[] = $row['email'];
+            }
+        }
+    }
+
+    if (empty($recipients)) {
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'message' => 'No valid recipients found for the selected target.']);
+        exit;
+    }
+
+    // Convert HTML body to a plain text version
+    $body_text = strip_tags($body_html);
+
+    $sent_count = 0;
+    $failed_count = 0;
+
+    foreach ($recipients as $recipient) {
+        if (sendEmail($recipient, $subject, $body_html, $body_text)) {
+            $sent_count++;
+        } else {
+            $failed_count++;
+        }
+        // Add a small delay to avoid hitting sending limits
+        usleep(100000); // 100ms
+    }
+
+    if ($sent_count > 0) {
+        echo json_encode([
+            'status' => 'success',
+            'message' => "Emails sent: {$sent_count}, Failed: {$failed_count}."
+        ]);
+    } else {
+        http_response_code(500);
+        echo json_encode([
+            'status' => 'error',
+            'message' => "Failed to send any emails. Please check server logs and email configuration."
+        ]);
+    }
+
+} else {
+    http_response_code(405); // Method Not Allowed
+    echo json_encode(['status' => 'error', 'message' => 'Invalid request method.']);
+}
+
+$conn->close();
+?>

--- a/js/admin.js
+++ b/js/admin.js
@@ -256,4 +256,60 @@ document.addEventListener('DOMContentLoaded', () => {
             showToast('An error occurred while updating the user.', 'error');
         }
     }
+
+    // --- Email Sender Logic ---
+    const emailTarget = document.getElementById('email-target');
+    const manualEmailsContainer = document.getElementById('manual-emails-container');
+    const sendEmailsBtn = document.getElementById('send-emails-btn');
+    const emailStatus = document.getElementById('email-status');
+
+    if (emailTarget) {
+        emailTarget.addEventListener('change', () => {
+            if (emailTarget.value === 'manual') {
+                manualEmailsContainer.style.display = 'block';
+            } else {
+                manualEmailsContainer.style.display = 'none';
+            }
+        });
+    }
+
+    if (sendEmailsBtn) {
+        sendEmailsBtn.addEventListener('click', async () => {
+            const target = document.getElementById('email-target').value;
+            const subject = document.getElementById('email-subject').value;
+            const body = document.getElementById('email-body').value;
+            const manual_emails = document.getElementById('manual-emails').value;
+
+            if (!subject || !body) {
+                showToast('Email subject and body cannot be empty.', 'error');
+                return;
+            }
+
+            if (target === 'manual' && !manual_emails) {
+                showToast('Please provide a list of manual emails.', 'error');
+                return;
+            }
+
+            sendEmailsBtn.disabled = true;
+            emailStatus.textContent = 'Sending...';
+
+            try {
+                const response = await fetch('api/admin/send_email.php', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ target: target, subject: subject, body: body, manual_emails: manual_emails })
+                });
+
+                const result = await response.json();
+                showToast(result.message, response.ok ? 'success' : 'error');
+
+            } catch (error) {
+                console.error('Error sending emails:', error);
+                showToast('An unexpected error occurred while sending emails.', 'error');
+            } finally {
+                sendEmailsBtn.disabled = false;
+                emailStatus.textContent = '';
+            }
+        });
+    }
 });


### PR DESCRIPTION
This commit introduces a new feature in the admin dashboard that allows administrators to send HTML-formatted emails to users.

- Adds an email broadcasting section to the admin panel UI.
- Administrators can target users by their subscription status (active, inactive, or all) or provide a manual list of email addresses.
- A new API endpoint (`api/admin/send_email.php`) is created to handle sending the emails using AWS SES.
- The frontend JavaScript is updated to manage the new UI and communicate with the backend API.