### PR TITLE
feat: Add performance tracking and progress display

### DIFF
--- a/api/get_dialogue.php
+++ b/api/get_dialogue.php
@@ -18,7 +18,7 @@ require_once '../db/db_config.php';
 $dialogue_id = $_GET['id'] ?? 1; // Default to the first dialogue
 
 $stmt = $conn->prepare(
-    "SELECT d.dialogue_name, dl.speaker, dl.line_text, dl.line_order
+    "SELECT d.id as dialogue_id, d.dialogue_name, dl.id as line_id, dl.speaker, dl.line_text, dl.line_order
      FROM dialogues d
      JOIN dialogue_lines dl ON d.id = dl.dialogue_id
      WHERE d.id = ?
@@ -29,6 +29,7 @@ $stmt->execute();
 $result = $stmt->get_result();
 
 $dialogue = [
+    'id' => $dialogue_id,
     'name' => '',
     'lines' => []
 ];
@@ -40,6 +41,7 @@ while ($row = $result->fetch_assoc()) {
         $first_row = false;
     }
     $dialogue['lines'][] = [
+        'id' => $row['line_id'],
         'speaker' => $row['speaker'],
         'line' => $row['line_text']
     ];

--- a/api/profile/get_dialogue_progress.php
+++ b/api/profile/get_dialogue_progress.php
@@ -1,0 +1,67 @@
+<?php
+session_start();
+header('Content-Type: application/json; charset=utf-8');
+
+// Security Check: Ensure user is logged in
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401); // Unauthorized
+    echo json_encode(['status' => 'error', 'message' => 'You must be logged in to view progress.']);
+    exit;
+}
+
+require_once '../../db/db_config.php';
+
+$user_id = $_SESSION['user_id'];
+
+// This query calculates the progress for each dialogue for the specific user.
+// It counts the total lines in each dialogue and joins it with the user's progress.
+$query = "
+    SELECT
+        d.id AS dialogue_id,
+        d.dialogue_name,
+        (SELECT COUNT(*) FROM dialogue_lines WHERE dialogue_id = d.id) AS total_lines,
+        COUNT(dp.id) AS attempted_lines,
+        AVG(dp.score) AS average_score
+    FROM
+        dialogues d
+    LEFT JOIN
+        dialogue_progress dp ON d.id = dp.dialogue_id AND dp.user_id = ?
+    GROUP BY
+        d.id, d.dialogue_name
+    ORDER BY
+        d.id;
+";
+
+$stmt = $conn->prepare($query);
+if (!$stmt) {
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => 'Failed to prepare statement: ' . $conn->error]);
+    exit;
+}
+
+$stmt->bind_param("i", $user_id);
+$stmt->execute();
+$result = $stmt->get_result();
+
+$progress_data = [];
+while ($row = $result->fetch_assoc()) {
+    $coverage = 0;
+    if ($row['total_lines'] > 0) {
+        $coverage = ($row['attempted_lines'] / $row['total_lines']);
+    }
+
+    $progress_data[] = [
+        'dialogue_id' => $row['dialogue_id'],
+        'dialogue_name' => $row['dialogue_name'],
+        'coverage' => $coverage,
+        'average_score' => $row['average_score'] ? (float)$row['average_score'] : 0,
+        'attempted_lines' => (int)$row['attempted_lines'],
+        'total_lines' => (int)$row['total_lines']
+    ];
+}
+
+$stmt->close();
+$conn->close();
+
+echo json_encode(['status' => 'success', 'progress' => $progress_data]);
+?>

--- a/api/profile/store_dialogue_progress.php
+++ b/api/profile/store_dialogue_progress.php
@@ -1,0 +1,62 @@
+<?php
+session_start();
+header('Content-Type: application/json; charset=utf-8');
+
+// Security Check: Ensure user is logged in
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401); // Unauthorized
+    echo json_encode(['status' => 'error', 'message' => 'You must be logged in to store progress.']);
+    exit;
+}
+
+require_once '../../db/db_config.php';
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+if ($method === 'POST') {
+    $data = json_decode(file_get_contents('php://input'), true);
+
+    $user_id = $_SESSION['user_id'];
+    $dialogue_id = $data['dialogue_id'] ?? null;
+    $line_id = $data['line_id'] ?? null;
+    $score = $data['score'] ?? null;
+
+    if ($dialogue_id === null || $line_id === null || $score === null) {
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'message' => 'Missing required fields: dialogue_id, line_id, and score.']);
+        exit;
+    }
+
+    // UPSERT operation: Insert a new record, or update the existing one if the user_id and line_id composite key exists.
+    $query = "
+        INSERT INTO dialogue_progress (user_id, dialogue_id, line_id, score, attempts)
+        VALUES (?, ?, ?, ?, 1)
+        ON DUPLICATE KEY UPDATE
+            score = VALUES(score),
+            attempts = attempts + 1
+    ";
+
+    $stmt = $conn->prepare($query);
+    if (!$stmt) {
+        http_response_code(500);
+        echo json_encode(['status' => 'error', 'message' => 'Failed to prepare statement: ' . $conn->error]);
+        exit;
+    }
+
+    $stmt->bind_param("iiid", $user_id, $dialogue_id, $line_id, $score);
+
+    if ($stmt->execute()) {
+        echo json_encode(['status' => 'success', 'message' => 'Progress saved successfully.']);
+    } else {
+        http_response_code(500);
+        echo json_encode(['status' => 'error', 'message' => 'Failed to save progress: ' . $stmt->error]);
+    }
+
+    $stmt->close();
+} else {
+    http_response_code(405); // Method Not Allowed
+    echo json_encode(['status' => 'error', 'message' => 'Invalid request method.']);
+}
+
+$conn->close();
+?>

--- a/db/setup_database.php
+++ b/db/setup_database.php
@@ -11,7 +11,8 @@ $sql_files = [
     __DIR__ . '/../sql/alter_roleplay_scenarios.sql',
     __DIR__ . '/../sql/update_roleplay_scenarios_level2.sql',
     __DIR__ . '/../sql/add_more_drills.sql',
-    __DIR__ . '/../sql/update_subscription_schema.sql'
+    __DIR__ . '/../sql/update_subscription_schema.sql',
+    __DIR__ . '/../sql/create_dialogue_progress_table.sql'
 ];
 
 echo "<h2>Database Setup</h2>";

--- a/index.html
+++ b/index.html
@@ -510,6 +510,7 @@
           <option value="">--Please choose a topic--</option>
           <!-- Options will be dynamically populated -->
       </select>
+      <span id="topic-progress-display" style="margin-left: 1rem; font-weight: bold; font-size: 0.9rem;"></span>
       <br />
       <label for="speechRate">Speech Speed:</label><br />
       <input type="range" id="speechRate" min="0.5" max="1.2" value="1.0" step="0.1" />
@@ -555,6 +556,19 @@ let currentPhraseIndex = 0;
 let currentTopic = '';
 let speechRate = 1.0;
 let recognition;
+let userProgress = [];
+
+async function fetchProgress() {
+    try {
+        const response = await fetch('api/profile/get_progress.php');
+        const data = await response.json();
+        if (data.status === 'success') {
+            userProgress = data.progress;
+        }
+    } catch (error) {
+        console.error('Failed to fetch user progress:', error);
+    }
+}
 
 // --- Utility Functions ---
 function speakFrench(text, rate) {
@@ -769,7 +783,26 @@ function initializeMainFlashcard() {
         }
     }
 
-    topicSelect.addEventListener('change', () => loadPhrases(topicSelect.value));
+    topicSelect.addEventListener('change', () => {
+        loadPhrases(topicSelect.value);
+
+        const selectedTopic = topicSelect.value;
+        const progressDisplay = document.getElementById('topic-progress-display');
+        if (!selectedTopic) {
+            progressDisplay.textContent = '';
+            return;
+        }
+        const [section, theme] = selectedTopic.split('-');
+
+        const topicProgress = userProgress.find(p => p.section === section && p.theme === theme);
+
+        if (topicProgress) {
+            const scorePercent = (topicProgress.average_matching_quality * 100).toFixed(0);
+            progressDisplay.textContent = `Progress: ${topicProgress.phrases_covered}/${topicProgress.total_phrases} phrases, Avg Score: ${scorePercent}%`;
+        } else {
+            progressDisplay.textContent = 'No progress yet.';
+        }
+    });
     flipCardBtn.addEventListener('click', (e) => { e.stopPropagation(); flashcard.classList.toggle('is-flipped'); });
     flashcard.addEventListener('click', () => flashcard.classList.toggle('is-flipped'));
     playPhraseBtn.addEventListener('click', () => { if (phraseFrench.textContent) speakFrench(phraseFrench.textContent, speechRate); });
@@ -943,6 +976,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     const mainFlashcard = initializeMainFlashcard();
                     const topicSelect = document.getElementById('topicSelect');
                     await populateTopics(topicSelect);
+                    await fetchProgress(); // Fetch progress data
                     if (data.user.last_topic) {
                         topicSelect.value = data.user.last_topic;
                         // Trigger the change event to load phrases

--- a/profile.html
+++ b/profile.html
@@ -93,9 +93,15 @@
 
         <div class="form-section">
             <h2>Your Progress</h2>
+            <h3>Flashcard Progress</h3>
             <div id="progress-container"></div>
-            <div style="margin-top: 1rem;">
-                <button id="reset-stats-btn" style="background-color: #dc3545;">Reset Stats</button>
+            <div style="margin-top: 1rem; margin-bottom: 2rem;">
+                <button id="reset-stats-btn" style="background-color: #dc3545;">Reset Flashcard Stats</button>
+            </div>
+
+            <h3>Phase 1: Shadowing Performance</h3>
+            <div id="dialogue-progress-container">
+                <!-- Dialogue progress will be loaded here -->
             </div>
         </div>
     </div>
@@ -150,6 +156,35 @@
         }
 
         fetchProgress();
+
+        async function fetchDialogueProgress() {
+            const response = await fetch('api/profile/get_dialogue_progress.php');
+            const data = await response.json();
+
+            if (data.status === 'success') {
+                const progressContainer = document.getElementById('dialogue-progress-container');
+                if (data.progress.length === 0) {
+                    progressContainer.innerHTML = '<p>No progress yet for Phase 1. Start practicing!</p>';
+                    return;
+                }
+
+                let html = '<table>';
+                html += '<tr><th>Dialogue</th><th>Coverage</th><th>Average Score</th></tr>';
+                data.progress.forEach(item => {
+                    const coveragePercent = (item.coverage * 100).toFixed(0);
+                    const scorePercent = (item.average_score * 100).toFixed(2);
+                    html += `<tr>
+                                <td>${item.dialogue_name}</td>
+                                <td>${coveragePercent}% (${item.attempted_lines}/${item.total_lines} lines)</td>
+                                <td>${scorePercent}%</td>
+                             </tr>`;
+                });
+                html += '</table>';
+                progressContainer.innerHTML = html;
+            }
+        }
+
+        fetchDialogueProgress();
 
         document.getElementById('reset-stats-btn').addEventListener('click', async () => {
             if (confirm('Are you sure you want to reset your stats? This action cannot be undone.')) {

--- a/sql/create_dialogue_progress_table.sql
+++ b/sql/create_dialogue_progress_table.sql
@@ -1,0 +1,19 @@
+-- Table to store user progress on dialogue lines for Phase 1
+CREATE TABLE IF NOT EXISTS `dialogue_progress` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `dialogue_id` int(11) NOT NULL,
+  `line_id` int(11) NOT NULL,
+  `score` float NOT NULL DEFAULT '0',
+  `attempts` int(11) NOT NULL DEFAULT '1',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_user_line` (`user_id`, `line_id`),
+  KEY `user_id` (`user_id`),
+  KEY `dialogue_id` (`dialogue_id`),
+  KEY `line_id` (`line_id`),
+  CONSTRAINT `dialogue_progress_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `dialogue_progress_ibfk_2` FOREIGN KEY (`dialogue_id`) REFERENCES `dialogues` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `dialogue_progress_ibfk_3` FOREIGN KEY (`line_id`) REFERENCES `dialogue_lines` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/training.html
+++ b/training.html
@@ -158,6 +158,7 @@
             <select id="dialogueSelect">
                 <!-- Options will be populated dynamically -->
             </select>
+            <span id="dialogue-progress-display" style="margin-left: 1rem; font-weight: bold; font-size: 0.9rem;"></span>
             <button id="play-full-dialogue-btn">Play Full Dialogue</button>
         </div>
         <div id="dialogue-content" style="margin-top: 1rem; padding: 1rem; background: #fff; border-radius: 8px;">
@@ -326,6 +327,19 @@ document.addEventListener('DOMContentLoaded', () => {
     loadSpeechRate(); // Load the saved rate on page load
 
     let recognition;
+    let dialogueProgress = [];
+
+    async function fetchDialogueProgress() {
+        try {
+            const response = await fetch('api/profile/get_dialogue_progress.php');
+            const data = await response.json();
+            if (data.status === 'success') {
+                dialogueProgress = data.progress;
+            }
+        } catch (error) {
+            console.error('Failed to fetch dialogue progress:', error);
+        }
+    }
 
     function stopRecording() {
         if (recognition) {
@@ -333,7 +347,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    function checkPronunciation(userTranscript, targetText, resultElement) {
+    function checkPronunciation(userTranscript, targetText, resultElement, dialogueId, lineId) {
         const target = targetText.toLowerCase().replace(/[.,!?;]/g, '');
         const userWords = userTranscript.toLowerCase().replace(/[.,!?;]/g, '').split(/\\s+/);
         const targetWords = target.split(/\\s+/);
@@ -355,12 +369,23 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         resultElement.textContent = ` ${resultText} (Score: ${score}%)`;
 
+        // Save the progress
+        fetch('api/profile/store_dialogue_progress.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                dialogue_id: dialogueId,
+                line_id: lineId,
+                score: ratio
+            })
+        });
+
         setTimeout(() => {
             resultElement.textContent = '';
         }, 5000);
     }
 
-    function startPronunciationCheck(targetText, resultElement) {
+    function startPronunciationCheck(targetText, resultElement, dialogueId, lineId) {
         if (!('SpeechRecognition' in window || 'webkitSpeechRecognition' in window)) {
             alert("Sorry, your browser does not support Speech Recognition.");
             return;
@@ -377,7 +402,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         recognition.onresult = (event) => {
             const transcript = event.results[0][0].transcript.toLowerCase();
-            checkPronunciation(transcript, targetText, resultElement);
+            checkPronunciation(transcript, targetText, resultElement, dialogueId, lineId);
         };
 
         recognition.onerror = (event) => {
@@ -511,15 +536,32 @@ document.addEventListener('DOMContentLoaded', () => {
         document.querySelectorAll('.check-pronunciation-btn').forEach(button => {
             button.addEventListener('click', (e) => {
                 const lineIndex = e.target.getAttribute('data-line-index');
-                const lineText = dialogue.lines[lineIndex].line;
+                const line = dialogue.lines[lineIndex];
                 const resultSpan = dialogueContent.querySelector(`.pronunciation-result[data-line-index="${lineIndex}"]`);
-                startPronunciationCheck(lineText, resultSpan);
+                startPronunciationCheck(line.line, resultSpan, dialogue.id, line.id);
             });
         });
     }
 
     dialogueSelect.addEventListener('change', () => {
         loadDialogue(dialogueSelect.value);
+
+        const selectedDialogueId = dialogueSelect.value;
+        const progressDisplay = document.getElementById('dialogue-progress-display');
+        if (!selectedDialogueId) {
+            progressDisplay.textContent = '';
+            return;
+        }
+
+        const progress = dialogueProgress.find(p => p.dialogue_id == selectedDialogueId);
+
+        if (progress && progress.attempted_lines > 0) {
+            const coveragePercent = (progress.coverage * 100).toFixed(0);
+            const scorePercent = (progress.average_score * 100).toFixed(0);
+            progressDisplay.textContent = `Coverage: ${coveragePercent}%, Avg Score: ${scorePercent}%`;
+        } else {
+            progressDisplay.textContent = 'No progress yet.';
+        }
     });
 
     playFullDialogueBtn.addEventListener('click', async () => {
@@ -548,7 +590,15 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // Initial load
-    loadDialogueList();
+    (async () => {
+        await fetchDialogueProgress();
+        await loadDialogueList();
+
+        // Since a dialogue is loaded automatically, trigger the change event to show its progress
+        if (dialogueSelect.value) {
+            dialogueSelect.dispatchEvent(new Event('change'));
+        }
+    })();
 
     // --- Phase 2: Question Drills ---
     const startDrillBtn = document.getElementById('start-drill-btn');


### PR DESCRIPTION
This commit introduces a new feature to track and display user progress for the flashcard and dialogue exercises.

- Adds a new `dialogue_progress` table to the database to store pronunciation scores for each dialogue line.
- Creates new API endpoints to save and retrieve this progress data.
- Updates the user's profile page to display a detailed breakdown of their performance in the Phase 1 Shadowing exercises, including coverage and average score per dialogue.
- Enhances the UI on the main flashcard and training pages to display the user's current progress for the selected topic or dialogue directly next to the dropdown menu, providing immediate feedback.