### PR TITLE
fix: Correct pronunciation score calculation

### DIFF
--- a/training.html
+++ b/training.html
@@ -349,8 +349,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function checkPronunciation(userTranscript, targetText, resultElement, dialogueId, lineId) {
         const target = targetText.toLowerCase().replace(/[.,!?;]/g, '');
-        const userWords = userTranscript.toLowerCase().replace(/[.,!?;]/g, '').split(/\\s+/);
-        const targetWords = target.split(/\\s+/);
+        const userWords = userTranscript.toLowerCase().replace(/[.,!?;]/g, '').split(/\s+/);
+        const targetWords = target.split(/\s+/);
 
         let matchCount = 0;
         targetWords.forEach(w => {


### PR DESCRIPTION
This commit fixes a bug in the speech recognition feature on the Phase 1 Shadowing page (`training.html`) where the pronunciation score was always returning 0%.

The issue was caused by an incorrect regular expression used to split the transcript and target sentences into words. The `split(/\\s+/)` was incorrectly escaping the backslash, causing it to fail to match whitespace.

The regex has been corrected to `split(/\s+/)`, which now correctly splits the strings by whitespace and allows the matching score to be calculated properly.