### PR TITLE
This commit fixes a regression where the user's flashcard position wa…

### DIFF
--- a/index.html
+++ b/index.html
@@ -811,6 +811,7 @@ function initializeMainFlashcard() {
         flashcard.classList.remove('is-flipped');
         updateNavButtons();
         currentCardSpan.textContent = idx + 1;
+        savePosition(currentTopic, idx);
     }
 
     function updateNavButtons() {


### PR DESCRIPTION
…s not being saved correctly.

The root cause was that the `savePosition()` function was only being called when a new topic was loaded, not when the user navigated between individual cards. This meant the `last_card_index` was never updated after the initial load.

I have moved the `savePosition(currentTopic, idx)` call into the `displayPhrase(idx)` function. Since `displayPhrase` is called every time a new card is shown, this ensures the user's current index is always saved to the backend, allowing them to correctly resume their session later.